### PR TITLE
issue-9: escaped more NA values in .plotFit

### DIFF
--- a/R/plotFit.R
+++ b/R/plotFit.R
@@ -260,7 +260,7 @@
     paste0("ASSAY:   ", aenm, "\n\n",
            "NAME:    ", chnm, "\n",
            "CHID:    ", chid, spaces(8 - nchar(chid)),
-           "CASRN: ", casn, "\n", # spaces(16-nchar(casn)),"AGBY: ",agby,"\n",
+           "CHID:    ", chid, spaces(8 - ifelse(is.na(chid), 2, nchar(chid))),
            "SPID(S): ", spid, "\n",
            "M4ID:    ", m4id, "  ", ifelse(brk, "BRK", ""), "\n\n"
     )
@@ -358,9 +358,15 @@
     
   }
   
-  aics <- with(pars, round(c(cnst_aic, hill_aic, gnls_aic), 2))
-  prob <- with(pars, round(c(cnst_prob, hill_prob, gnls_prob), 2))
-  rmse <- with(pars, round(c(cnst_rmse, hill_rmse, gnls_rmse), 2))
+  cvals <- function(x) {
+    x <- as.character(x)
+    x[is.na(x)] <- "NA"
+    x
+  }
+  
+  aics <- cvals(with(pars, round(c(cnst_aic, hill_aic, gnls_aic), 2)))
+  prob <- cvals(with(pars, round(c(cnst_prob, hill_prob, gnls_prob), 2)))
+  rmse <- cvals(with(pars, round(c(cnst_rmse, hill_rmse, gnls_rmse), 2)))
   models <- c("CNST", "HILL", "GNLS")
   
   atxt <- paste0(spaces(6), 

--- a/R/plotFit.R
+++ b/R/plotFit.R
@@ -259,8 +259,8 @@
   itxt <- with(pars, {
     paste0("ASSAY:   ", aenm, "\n\n",
            "NAME:    ", chnm, "\n",
-           "CHID:    ", chid, spaces(8 - nchar(chid)),
            "CHID:    ", chid, spaces(8 - ifelse(is.na(chid), 2, nchar(chid))),
+           "CASRN: ", casn, "\n",
            "SPID(S): ", spid, "\n",
            "M4ID:    ", m4id, "  ", ifelse(brk, "BRK", ""), "\n\n"
     )


### PR DESCRIPTION
Similar to issue-2, the new nchar behavior with
R3.3 was causing errors. Additional changes were
made to prevent NA values being sent to nchar that
were missed when fixing issue-2.