### PR TITLE
issue-5: paritially fix RSQLite update bugs

### DIFF
--- a/R/tcplAppend.R
+++ b/R/tcplAppend.R
@@ -58,6 +58,8 @@ tcplAppend <- function(dat, tbl, db) {
                                 paste(tmp_flds, collapse = ","),
                                 "FROM",
                                 tempTbl))
+    dbClearResult(status)
+    
     # Remove temporary table
     dbRemoveTable(dbcon, tempTbl)
     

--- a/R/tcplQuery.R
+++ b/R/tcplQuery.R
@@ -6,7 +6,7 @@
 #' 
 #' @import DBI
 #' @importFrom RSQLite SQLite 
-#' @importMethodsFrom RSQLite dbConnect dbDisconnect dbGetQuery 
+#' @importMethodsFrom RSQLite dbConnect dbDisconnect
 #' @import data.table
 #' @importFrom RMySQL MySQL
 #' @importMethodsFrom RMySQL dbConnect dbDisconnect 
@@ -59,7 +59,7 @@ tcplQuery <- function(query, db = getOption("TCPL_DB"),
   }
   
   dbcon <- do.call(dbConnect, db_pars)
-  result <- dbGetQuery(dbcon, query)
+  result <- DBI::dbGetQuery(dbcon, query)
   
   dbDisconnect(dbcon)
   


### PR DESCRIPTION
In the development version (as of 160722) of RSQLite  trying to
close a connection after calling dbSendQuery causes a warning asking
the user to close the result set. Adding a dbClearResults in
tcplAppend to fix the issue.

Also, the new RSQLite package does not export dbGetQuery, so the
call to dbGetQuery in tcplQuery is changed to DBI::dbGetQuery as
suggested by the RSQLite developers. Likewise, the NAMESPACE is
updated to no longer import dbGetQuery from RSQLite.

Have not yet addressed the class issue when loading a table with
NULL values.